### PR TITLE
add required parameter 'response_type' to auth url

### DIFF
--- a/yandex_money/api.py
+++ b/yandex_money/api.py
@@ -231,7 +231,8 @@ class Wallet(BasePayment):
                                               urlencode({
                                                   "client_id": client_id,
                                                   "redirect_uri": redirect_uri,
-                                                  "scope": " ".join(scope)
+                                                  "scope": " ".join(scope),
+                                                  "response_type": "code"
                                               }))
 
     @classmethod


### PR DESCRIPTION
YaMoney API rejects requests without `response_type=code` parameter. [documentation page](https://tech.yandex.ru/money/doc/dg/reference/request-access-token-docpage/)
